### PR TITLE
TextList.AtBytes() and StringBytes() allow string field access as []byte and without allocation

### DIFF
--- a/capnpc-go/templates.go
+++ b/capnpc-go/templates.go
@@ -191,6 +191,14 @@ func (s {{.Node.Name}}) {{.Field.Name|title}}() (string, error) {
 	{{end}}
 }
 
+func (s {{.Node.Name}}) {{.Field.Name|title}}Bytes() ([]byte, error) {
+	p, err := s.Struct.Pointer({{.Field.Slot.Offset}})
+	if err != nil {
+		return nil, err
+	}
+	return {{capnp}}.ToData(p), nil
+}
+
 func (s {{.Node.Name}}) Set{{.Field.Name|title}}(v string) error {
 	{{template "settag" .}}
 	t, err := {{capnp}}.NewText(s.Struct.Segment(), v)

--- a/list.go
+++ b/list.go
@@ -273,6 +273,16 @@ func (l TextList) At(i int) (string, error) {
 	return ToText(p), nil
 }
 
+// At returns the i'th string in the list, but as []byte, to avoid copying.
+func (l TextList) AtBytes(i int) ([]byte, error) {
+	addr, _ := l.elem(i)
+	p, err := l.seg.readPtr(addr)
+	if err != nil {
+		return nil, err
+	}
+	return ToData(p), nil
+}
+
 // Set sets the i'th string in the list to v.
 func (l TextList) Set(i int, v string) error {
 	addr, _ := l.elem(i)


### PR DESCRIPTION
Fixes #17 

still todo: needs test/benchmarks. I wrote these for v1 here:
https://github.com/glycerine/go-capnproto/blob/master/stringbytes_test.go
