### PR TITLE
mem: skip defer for performance

### DIFF
--- a/mem.go
+++ b/mem.go
@@ -167,22 +167,27 @@ func (m *Message) NumSegments() int64 {
 
 // Segment returns the segment with the given ID.
 func (m *Message) Segment(id SegmentID) (*Segment, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	var seg *Segment
 	if isInt32Bit() && id > maxInt32 {
 		return nil, errSegment32Bit
 	}
-	if seg := m.segment(id); seg != nil {
+	m.mu.Lock()
+	if seg = m.segment(id); seg != nil {
+		m.mu.Unlock()
 		return seg, nil
 	}
 	if int64(id) >= m.Arena.NumSegments() {
+		m.mu.Unlock()
 		return nil, errSegmentOutOfBounds
 	}
 	data, err := m.Arena.Data(id)
 	if err != nil {
+		m.mu.Unlock()
 		return nil, err
 	}
-	return m.setSegment(id, data), nil
+	seg = m.setSegment(id, data)
+	m.mu.Unlock()
+	return seg, nil
 }
 
 // segment returns the segment with the given ID.
@@ -230,19 +235,23 @@ func (m *Message) setSegment(id SegmentID, data []byte) *Segment {
 // cap(seg.Data) - len(seg.Data) >= sz.
 func (m *Message) allocSegment(sz Size) (*Segment, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	var seg *Segment
 	if m.segs == nil && m.firstSeg.msg != nil {
 		m.segs = make(map[SegmentID]*Segment)
 		m.segs[0] = &m.firstSeg
 	}
 	id, data, err := m.Arena.Allocate(sz, m.segs)
 	if err != nil {
+		m.mu.Unlock()
 		return nil, err
 	}
 	if isInt32Bit() && id > maxInt32 {
+		m.mu.Unlock()
 		return nil, errSegment32Bit
 	}
-	return m.setSegment(id, data), nil
+	seg = m.setSegment(id, data)
+	m.mu.Unlock()
+	return seg, nil
 }
 
 // alloc allocates sz zero-filled bytes.  It prefers using s, but may


### PR DESCRIPTION
We're looking to move to go-capnproto2 from the original and we've been comparing the performance of the two using [alecthomas' go serialization benchmark suite](https://github.com/alecthomas/go_serialization_benchmarks).

This is a minor patch which improves the speed moderately.  We're still looking at options for increasing the speed.  Most of them probably involve changing the go structs to pointers, if that's amenable to you.

Here's the performance comparison with and without this changeset:

https://gist.github.com/abraithwaite/a8876d351edf16bc052cd6b5acdaa330

I'm not sure why the svgs don't render nicely on gist though :-(