### PR TITLE
Add benchmarks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,4 +23,5 @@ Joonsung Lee <joonsung@devsisters.com>
 Lev Radomislensky <lev.radomislensky@gmail.com>
 Peter Waldschmidt <peterw@gnoso.com>
 Tom Thorogood <me+github@tomthorogood.co.uk>
+TJ Holowaychuk <tj@apex.sh>
 William Laffin <william.laffin@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,4 +29,5 @@ Lev Radomislensky <lev.radomislensky@gmail.com>
 Peter Waldschmidt <peterw@gnoso.com>
 Ross Light <light@google.com> <ross@zombiezen.com>
 Tom Thorogood <me+github@tomthorogood.co.uk>
+TJ Holowaychuk <tj@apex.sh>
 William Laffin <william.laffin@gmail.com>

--- a/msgp_bench_gen_test.go
+++ b/msgp_bench_gen_test.go
@@ -1,3 +1,5 @@
+// +build msgp
+
 package capnp_test
 
 // NOTE: THIS FILE WAS PRODUCED BY THE

--- a/msgp_bench_gen_test.go
+++ b/msgp_bench_gen_test.go
@@ -1,4 +1,4 @@
-// +build msgp
+// +build msgpbench
 
 package capnp_test
 

--- a/msgp_bench_gen_test.go
+++ b/msgp_bench_gen_test.go
@@ -1,0 +1,213 @@
+package capnp_test
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"github.com/tinylib/msgp/msgp"
+)
+
+// DecodeMsg implements msgp.Decodable
+func (z *Event) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zxvk uint32
+	zxvk, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zxvk > 0 {
+		zxvk--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Name":
+			z.Name, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "BirthDay":
+			z.BirthDay, err = dc.ReadTime()
+			if err != nil {
+				return
+			}
+		case "Phone":
+			z.Phone, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Siblings":
+			z.Siblings, err = dc.ReadInt()
+			if err != nil {
+				return
+			}
+		case "Spouse":
+			z.Spouse, err = dc.ReadBool()
+			if err != nil {
+				return
+			}
+		case "Money":
+			z.Money, err = dc.ReadFloat64()
+			if err != nil {
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *Event) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 6
+	// write "Name"
+	err = en.Append(0x86, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Name)
+	if err != nil {
+		return
+	}
+	// write "BirthDay"
+	err = en.Append(0xa8, 0x42, 0x69, 0x72, 0x74, 0x68, 0x44, 0x61, 0x79)
+	if err != nil {
+		return err
+	}
+	err = en.WriteTime(z.BirthDay)
+	if err != nil {
+		return
+	}
+	// write "Phone"
+	err = en.Append(0xa5, 0x50, 0x68, 0x6f, 0x6e, 0x65)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Phone)
+	if err != nil {
+		return
+	}
+	// write "Siblings"
+	err = en.Append(0xa8, 0x53, 0x69, 0x62, 0x6c, 0x69, 0x6e, 0x67, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt(z.Siblings)
+	if err != nil {
+		return
+	}
+	// write "Spouse"
+	err = en.Append(0xa6, 0x53, 0x70, 0x6f, 0x75, 0x73, 0x65)
+	if err != nil {
+		return err
+	}
+	err = en.WriteBool(z.Spouse)
+	if err != nil {
+		return
+	}
+	// write "Money"
+	err = en.Append(0xa5, 0x4d, 0x6f, 0x6e, 0x65, 0x79)
+	if err != nil {
+		return err
+	}
+	err = en.WriteFloat64(z.Money)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *Event) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 6
+	// string "Name"
+	o = append(o, 0x86, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.Name)
+	// string "BirthDay"
+	o = append(o, 0xa8, 0x42, 0x69, 0x72, 0x74, 0x68, 0x44, 0x61, 0x79)
+	o = msgp.AppendTime(o, z.BirthDay)
+	// string "Phone"
+	o = append(o, 0xa5, 0x50, 0x68, 0x6f, 0x6e, 0x65)
+	o = msgp.AppendString(o, z.Phone)
+	// string "Siblings"
+	o = append(o, 0xa8, 0x53, 0x69, 0x62, 0x6c, 0x69, 0x6e, 0x67, 0x73)
+	o = msgp.AppendInt(o, z.Siblings)
+	// string "Spouse"
+	o = append(o, 0xa6, 0x53, 0x70, 0x6f, 0x75, 0x73, 0x65)
+	o = msgp.AppendBool(o, z.Spouse)
+	// string "Money"
+	o = append(o, 0xa5, 0x4d, 0x6f, 0x6e, 0x65, 0x79)
+	o = msgp.AppendFloat64(o, z.Money)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *Event) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zbzg uint32
+	zbzg, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zbzg > 0 {
+		zbzg--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Name":
+			z.Name, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "BirthDay":
+			z.BirthDay, bts, err = msgp.ReadTimeBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Phone":
+			z.Phone, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Siblings":
+			z.Siblings, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Spouse":
+			z.Spouse, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Money":
+			z.Money, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *Event) Msgsize() (s int) {
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 9 + msgp.TimeSize + 6 + msgp.StringPrefixSize + len(z.Phone) + 9 + msgp.IntSize + 7 + msgp.BoolSize + 6 + msgp.Float64Size
+	return
+}

--- a/msgp_bench_test.go
+++ b/msgp_bench_test.go
@@ -1,4 +1,6 @@
 // +build msgp
+//go:generate msgp -tests=false -o msgp_bench_gen_test.go
+//msgp:Tuple Event
 
 package capnp_test
 
@@ -14,9 +16,6 @@ import (
 
 	"github.com/tinylib/msgp/msgp"
 )
-
-//go:generate msgp -tests=false -o msgp_bench_gen_test.go
-//msgp:Tuple Event
 
 type Event struct {
 	Name     string

--- a/msgp_bench_test.go
+++ b/msgp_bench_test.go
@@ -86,7 +86,7 @@ func BenchmarkUnmarshalMsgpReader(b *testing.B) {
 	}
 }
 
-func BenchmarkUnmarshalDecoder(b *testing.B) {
+func BenchmarkDecode(b *testing.B) {
 	var buf bytes.Buffer
 
 	r := rand.New(rand.NewSource(12345))

--- a/msgp_bench_test.go
+++ b/msgp_bench_test.go
@@ -117,6 +117,10 @@ func BenchmarkDecode(b *testing.B) {
 				break
 			}
 
+			if err != nil {
+				b.Fatal(err)
+			}
+
 			_, err = air.ReadRootBenchmarkA(msg)
 			if err != nil {
 				b.Fatal(err)

--- a/msgp_bench_test.go
+++ b/msgp_bench_test.go
@@ -1,0 +1,40 @@
+package capnp_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+//go:generate msgp -tests=false -o msgp_bench_gen_test.go
+//msgp:Tuple Event
+
+type Event struct {
+	Name     string
+	BirthDay time.Time
+	Phone    string
+	Siblings int
+	Spouse   bool
+	Money    float64
+}
+
+func BenchmarkUnmarshalMsgp(b *testing.B) {
+	r := rand.New(rand.NewSource(12345))
+	data := make([][]byte, 1000)
+	for i := range data {
+		msg, _ := (*Event)(generateA(r)).MarshalMsg(nil)
+		data[i] = msg
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var e Event
+		msg := data[r.Intn(len(data))]
+		_, err := e.UnmarshalMsg(msg)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/msgp_bench_test.go
+++ b/msgp_bench_test.go
@@ -1,3 +1,5 @@
+// +build msgp
+
 package capnp_test
 
 import (

--- a/msgp_bench_test.go
+++ b/msgp_bench_test.go
@@ -3,7 +3,6 @@ package capnp_test
 import (
 	"bytes"
 	"io"
-	"log"
 	"math/rand"
 	"testing"
 	"time"
@@ -58,7 +57,7 @@ func BenchmarkUnmarshalMsgpReader(b *testing.B) {
 		event := (*Event)(generateA(r))
 		err := event.EncodeMsg(w)
 		if err != nil {
-			log.Fatal(err)
+			b.Fatal(err)
 		}
 	}
 
@@ -81,7 +80,7 @@ func BenchmarkUnmarshalMsgpReader(b *testing.B) {
 			}
 
 			if err != nil {
-				log.Fatal(err)
+				b.Fatal(err)
 			}
 		}
 	}
@@ -120,7 +119,7 @@ func BenchmarkUnmarshalDecoder(b *testing.B) {
 
 			_, err = air.ReadRootBenchmarkA(msg)
 			if err != nil {
-				log.Fatal(err)
+				b.Fatal(err)
 			}
 		}
 	}

--- a/msgp_bench_test.go
+++ b/msgp_bench_test.go
@@ -1,4 +1,4 @@
-// +build msgp
+// +build msgpbench
 //go:generate msgp -tests=false -o msgp_bench_gen_test.go
 //msgp:Tuple Event
 

--- a/msgp_bench_test.go
+++ b/msgp_bench_test.go
@@ -11,9 +11,6 @@ import (
 	"testing"
 	"time"
 
-	capnp "zombiezen.com/go/capnproto2"
-	air "zombiezen.com/go/capnproto2/internal/aircraftlib"
-
 	"github.com/tinylib/msgp/msgp"
 )
 
@@ -80,49 +77,6 @@ func BenchmarkUnmarshalMsgpReader(b *testing.B) {
 				break
 			}
 
-			if err != nil {
-				b.Fatal(err)
-			}
-		}
-	}
-}
-
-func BenchmarkDecode(b *testing.B) {
-	var buf bytes.Buffer
-
-	r := rand.New(rand.NewSource(12345))
-	enc := capnp.NewEncoder(&buf)
-	count := 10000
-
-	for i := 0; i < count; i++ {
-		a := generateA(r)
-		msg, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
-		root, _ := air.NewRootBenchmarkA(seg)
-		a.fill(root)
-		enc.Encode(msg)
-	}
-
-	blob := buf.Bytes()
-
-	b.ReportAllocs()
-	b.SetBytes(int64(buf.Len()))
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		dec := capnp.NewDecoder(bytes.NewReader(blob))
-
-		for {
-			msg, err := dec.Decode()
-
-			if err == io.EOF {
-				break
-			}
-
-			if err != nil {
-				b.Fatal(err)
-			}
-
-			_, err = air.ReadRootBenchmarkA(msg)
 			if err != nil {
 				b.Fatal(err)
 			}


### PR DESCRIPTION
RE #79 

Hopefully not misusing the API in the bench. Output on my MBP illustrating the comparison with msgp, even without decoding any fields from the capn msg. 

```
BenchmarkUnmarshal-8             	 2000000	       777 ns/op	     208 B/op	       3 allocs/op
BenchmarkUnmarshal_Reuse-8       	 5000000	       282 ns/op	       0 B/op	       0 allocs/op
BenchmarkUnmarshalMsgp-8         	 5000000	       281 ns/op	      32 B/op	       2 allocs/op
BenchmarkUnmarshalMsgpReader-8   	     500	   3299178 ns/op	 294.01 MB/s	  322376 B/op	   20004 allocs/op
BenchmarkUnmarshalDecoder-8      	     300	   5520729 ns/op	 173.89 MB/s	 3200052 B/op	   60002 allocs/op
```

Hopefully I'll have some time this week to check out a solution if you don't get to it first! Looks like it should be comparable if all else is equal.

